### PR TITLE
Handle nil `IO.console`

### DIFF
--- a/lib/tty/screen.rb
+++ b/lib/tty/screen.rb
@@ -78,6 +78,7 @@ module TTY
     def from_io_console
       return if jruby?
       Kernel.require 'io/console'
+      return unless IO.console
       size = IO.console.winsize
       size if nonzero_column?(size[1])
     rescue LoadError

--- a/spec/unit/size_spec.rb
+++ b/spec/unit/size_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe TTY::Screen, '.size' do
       allow(Kernel).to receive(:require).with('io/console').and_raise(LoadError)
       expect(screen.from_io_console).to eq(nil)
     end
+
+    it "doesn't calculate size if it is run without a console" do
+      require 'io/console'
+      allow(IO).to receive(:console).and_return(nil)
+      expect(screen.from_io_console).to eq(nil)
+    end
   end
 
   context 'from tput' do


### PR DESCRIPTION
We use `tty-screen` in one of our Jenkins jobs where `IO.console` returns `nil` and raised an `NoMethodError`. This pull request fixes this issue.