### PR TITLE
Only load IO.console in TTY terminals

### DIFF
--- a/lib/tty/screen.rb
+++ b/lib/tty/screen.rb
@@ -88,6 +88,7 @@ module TTY
     # @api private
     def from_io_console
       return if jruby?
+      return unless $stdout.tty?
       Kernel.require 'io/console'
       return unless IO.respond_to?(:console)
       size = IO.console.winsize


### PR DESCRIPTION
Hi

I've got ```NoMethodError: undefined method `winsize' for nil:NilClass``` error when running ```TTY::Screen.new.width``` code on jenkins.

This is solution found in https://github.com/pry/pry/commit/00f7877b0f8c3cdf3810093063e7f7c349d16749.